### PR TITLE
fix: 회의록 삭제, Confluence 업로드, 화자별 색상 구분 기능 개선

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -476,8 +476,8 @@ export const meetingApi = {
   },
 
   // Confluence 업로드
-  uploadToConfluence: async (meetingId: number): Promise<ApiResponse<{ message: string }>> => {
-    return fetchApi<{ message: string }>(
+  uploadToConfluence: async (meetingId: number): Promise<ApiResponse<{ message: string; confluence_page_url?: string }>> => {
+    return fetchApi<{ message: string; confluence_page_url?: string }>(
       `/meetings/${meetingId}/confluence/upload`,
       { method: 'POST' },
       true

--- a/app/settings/TeamSettings.tsx
+++ b/app/settings/TeamSettings.tsx
@@ -36,6 +36,7 @@ export default function TeamSettings({ teamId }: TeamSettingsProps) {
         setSettings(response.data);
         setConfluenceSiteUrl(response.data.confluence_site_url || '');
         setConfluenceSpaceKey(response.data.confluence_space_key || '');
+        setConfluenceParentPageId(response.data.confluence_parent_page_id || '');
         setSlackDefaultChannel(response.data.slack_default_channel || '');
       } else {
         setError(response.error?.message || '설정을 불러오는데 실패했습니다.');


### PR DESCRIPTION
## Summary
- 회의록 삭제 시 DELETE 요청 처리 수정 (204 No Content 응답 처리)
- Confluence 업로드 POST 요청 시 body 없는 경우 처리
- Confluence 업로드 후 URL 표시 및 2초 후 자동 새로고침
- 전체 대화 화자별 색상 구분 (10가지 색상)
- 팀 설정에서 confluence_parent_page_id 로드 추가

## Test plan
- [ ] 회의록 삭제 기능 테스트
- [ ] Confluence 업로드 기능 테스트
- [ ] 화자별 색상 구분 확인
- [ ] 팀 설정 저장/로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)